### PR TITLE
Changed the net.md_5.bungee.api.ChatColor to org.bukkit.ChatColor 

### DIFF
--- a/src/main/java/com/syntaxphoenix/spigot/smoothtimber/config/Message.java
+++ b/src/main/java/com/syntaxphoenix/spigot/smoothtimber/config/Message.java
@@ -1,8 +1,8 @@
 package com.syntaxphoenix.spigot.smoothtimber.config;
 
 import com.syntaxphoenix.spigot.smoothtimber.config.config.MessageConfig;
+import org.bukkit.ChatColor;
 
-import net.md_5.bungee.api.ChatColor;
 
 public enum Message {
 

--- a/src/main/java/com/syntaxphoenix/spigot/smoothtimber/utilities/Centering.java
+++ b/src/main/java/com/syntaxphoenix/spigot/smoothtimber/utilities/Centering.java
@@ -2,7 +2,7 @@ package com.syntaxphoenix.spigot.smoothtimber.utilities;
 
 import com.syntaxphoenix.syntaxapi.utils.java.lang.StringBuilder;
 
-import net.md_5.bungee.api.ChatColor;
+import org.bukkit.ChatColor;
 
 public final class Centering {
 

--- a/src/main/java/com/syntaxphoenix/spigot/smoothtimber/utilities/PluginUtils.java
+++ b/src/main/java/com/syntaxphoenix/spigot/smoothtimber/utilities/PluginUtils.java
@@ -32,7 +32,7 @@ import com.syntaxphoenix.spigot.smoothtimber.version.manager.VersionExchanger;
 import com.syntaxphoenix.syntaxapi.utils.java.Arrays;
 import com.syntaxphoenix.syntaxapi.utils.java.Exceptions;
 
-import net.md_5.bungee.api.ChatColor;
+import org.bukkit.ChatColor;
 
 public class PluginUtils {
 


### PR DESCRIPTION
Craftbukkit doesn't natively include the bungee api. As those two imports provide the same functionality in this case, I'd suggest doing so to prevent an error from occurring. 