### PR TITLE
Fix compatibility for LogBlocks package refactor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.syntaxphoenix.spigot</groupId>
 	<artifactId>smoothtimber-legacy</artifactId>
-	<version>1.18.0</version>
+	<version>1.18.1</version>
 	<name>SmoothTimber</name>
 	<packaging>jar</packaging>
 

--- a/src/main/java/com/syntaxphoenix/spigot/smoothtimber/compatibility/logblock/LogBlockDatabaseAccessor.java
+++ b/src/main/java/com/syntaxphoenix/spigot/smoothtimber/compatibility/logblock/LogBlockDatabaseAccessor.java
@@ -13,7 +13,10 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Used for accessing the logblock database, because the api queries to much not needed information,
@@ -21,9 +24,9 @@ import java.util.Set;
  */
 public class LogBlockDatabaseAccessor {
 
-    private static final Set<Material> EMPTY_MATERIALS = Set.of(
-            Material.AIR, Material.CAVE_AIR, Material.VOID_AIR
-    );
+    private static final Set<Material> EMPTY_MATERIALS = Stream.of(
+            Material.AIR, Material.getMaterial("CAVE_AIR"), Material.getMaterial("VOID_AIR")
+    ).filter(Objects::nonNull).collect(Collectors.toSet());
 
     private final LogBlock logBlock;
 
@@ -44,10 +47,10 @@ public class LogBlockDatabaseAccessor {
             try (ResultSet resultSet = statement.executeQuery()) {
                 if (!resultSet.next())
                     return false;
-                if(resultSet.getInt("playerid") < 0)
+                if (resultSet.getInt("playerid") < 0)
                     return false;
                 Material type = MaterialConverter.getMaterial(resultSet.getInt("type"));
-                if(type.name().endsWith("SAPLING"))
+                if (type.name().endsWith("SAPLING"))
                     return false;
                 return !EMPTY_MATERIALS.contains(type);
             }

--- a/src/main/java/com/syntaxphoenix/spigot/smoothtimber/compatibility/logblock/LogBlockDatabaseAccessor.java
+++ b/src/main/java/com/syntaxphoenix/spigot/smoothtimber/compatibility/logblock/LogBlockDatabaseAccessor.java
@@ -5,7 +5,6 @@ import de.diddiz.LogBlock.LogBlock;
 import de.diddiz.LogBlock.MaterialConverter;
 import de.diddiz.LogBlock.config.Config;
 import de.diddiz.LogBlock.config.WorldConfig;
-import de.diddiz.util.BukkitUtils;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.block.Block;
@@ -14,12 +13,17 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Set;
 
 /**
  * Used for accessing the logblock database, because the api queries to much not needed information,
  * which slow things down enormously.
  */
 public class LogBlockDatabaseAccessor {
+
+    private static final Set<Material> EMPTY_MATERIALS = Set.of(
+            Material.AIR, Material.CAVE_AIR, Material.VOID_AIR
+    );
 
     private final LogBlock logBlock;
 
@@ -45,7 +49,7 @@ public class LogBlockDatabaseAccessor {
                 Material type = MaterialConverter.getMaterial(resultSet.getInt("type"));
                 if(type.name().endsWith("SAPLING"))
                     return false;
-                return !BukkitUtils.isEmpty(type);
+                return !EMPTY_MATERIALS.contains(type);
             }
         } catch (SQLException throwables) {
             SmoothTimber.get().getLogger().severe("Failed to connect to LogBlock database");


### PR DESCRIPTION
Fixes #23

Removed access to BukkitUtil to keep backwards compatbility and created collection of empty materials instead. same logic, without LB access.

Why? https://github.com/LogBlock/LogBlock/commit/e430ee073f074ab7c7fb827253d54a9c3a492128