### PR TITLE
synchronize GriefPrevention calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.syntaxphoenix.spigot</groupId>
 	<artifactId>smoothtimber-legacy</artifactId>
-	<version>1.18.1</version>
+	<version>1.18.2</version>
 	<name>SmoothTimber</name>
 	<packaging>jar</packaging>
 

--- a/src/main/java/com/syntaxphoenix/spigot/smoothtimber/compatibility/griefprevention/GriefPreventionChopListener.java
+++ b/src/main/java/com/syntaxphoenix/spigot/smoothtimber/compatibility/griefprevention/GriefPreventionChopListener.java
@@ -2,6 +2,8 @@ package com.syntaxphoenix.spigot.smoothtimber.compatibility.griefprevention;
 
 import java.util.UUID;
 
+import com.syntaxphoenix.spigot.smoothtimber.utilities.PluginUtils;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -29,16 +31,18 @@ public final class GriefPreventionChopListener implements Listener {
         if (store.getPlayerData(uniqueId).ignoreClaims) {
             return;
         }
-        for (Location location : event.getBlockLocations()) {
-            Claim claim = store.getClaimAt(location, false, null);
-            if (claim == null) {
-                continue;
+        Bukkit.getScheduler().runTask(PluginUtils.MAIN, () -> {
+            for (Location location : event.getBlockLocations()) {
+                Claim claim = store.getClaimAt(location, false, null);
+                if (claim == null) {
+                    continue;
+                }
+                if (claim.allowBreak(player, location.getBlock().getType()) != null) {
+                    event.setCancelled(true);
+                    event.setReason(DefaultReason.GRIEFPREVENTION);
+                    return;
+                }
             }
-            if (claim.allowBreak(player, location.getBlock().getType()) != null) {
-                event.setCancelled(true);
-                event.setReason(DefaultReason.GRIEFPREVENTION);
-                return;
-            }
-        }
+        });
     }
 }


### PR DESCRIPTION
Fixes #25

Why? https://github.com/TechFortress/GriefPrevention/commit/bbb1e5d58c1da68265e677d8385988ea96ca3c73 added a permission check incl. event which must be called synchronously.
Whole GriefPrevention stuff is wrapped in synchronous call, as return in loop wouldn't be possible if only Claim#allowBreak would be called synchronously and the Main-Thread-Join would take ages in comparison to the current solution.