### PR TITLE
Add anyblock support (eg: leaves and more). Block list configurable in the config file

### DIFF
--- a/src/main/java/com/syntaxphoenix/spigot/smoothtimber/config/config/CutterConfig.java
+++ b/src/main/java/com/syntaxphoenix/spigot/smoothtimber/config/config/CutterConfig.java
@@ -47,6 +47,9 @@ public final class CutterConfig extends STConfig {
     public static boolean ENABLE_EXCLUSION = false;
     public static List<Material> EXCLUDED_MATERIALS = new ArrayList<>();
 
+    public static boolean ENABLE_INCLUSION = false;
+    public static List<Material> INCLUDED_MATERIALS = new ArrayList<>();
+
     public static boolean ENABLE_WORLD = false;
     public static boolean ENABLE_WORLD_BLACKLIST = false;
     public static List<String> WORLD_LIST;
@@ -115,6 +118,9 @@ public final class CutterConfig extends STConfig {
 
         ENABLE_EXCLUSION = check("exclusion.enabled", ENABLE_EXCLUSION);
         EXCLUDED_MATERIALS = check("exclusion.list", EXCLUDED_MATERIALS);
+
+        ENABLE_INCLUSION = check("inclusion.enabled", ENABLE_INCLUSION);
+        INCLUDED_MATERIALS = check("inclusion.list", INCLUDED_MATERIALS);
 
         ENABLE_WORLD = check("worlds.enabled", ENABLE_WORLD);
         ENABLE_WORLD_BLACKLIST = check("worlds.blacklist", ENABLE_WORLD_BLACKLIST);

--- a/src/main/java/com/syntaxphoenix/spigot/smoothtimber/config/config/CutterConfig.java
+++ b/src/main/java/com/syntaxphoenix/spigot/smoothtimber/config/config/CutterConfig.java
@@ -17,6 +17,8 @@ import com.syntaxphoenix.spigot.smoothtimber.utilities.cooldown.CooldownHelper;
 import com.syntaxphoenix.spigot.smoothtimber.utilities.limit.Limiter;
 import com.syntaxphoenix.spigot.smoothtimber.utilities.locate.Locator;
 
+import static org.bukkit.Bukkit.getLogger;
+
 public final class CutterConfig extends STConfig {
 
     public static final CutterConfig INSTANCE = new CutterConfig();
@@ -120,7 +122,17 @@ public final class CutterConfig extends STConfig {
         EXCLUDED_MATERIALS = check("exclusion.list", EXCLUDED_MATERIALS);
 
         ENABLE_INCLUSION = check("inclusion.enabled", ENABLE_INCLUSION);
-        INCLUDED_MATERIALS = check("inclusion.list", INCLUDED_MATERIALS);
+        List<Material> includedMaterials = check("inclusion.list", INCLUDED_MATERIALS);
+
+        // Materials have to be solid
+        INCLUDED_MATERIALS.clear();
+        for (Material includedMaterial : includedMaterials) {
+            if (includedMaterial.isSolid()) {
+                INCLUDED_MATERIALS.add(includedMaterial);
+            }else{
+                getLogger().info("Ignoring invalid material '"+includedMaterial+"' in the inclusion.list");
+            }
+        }
 
         ENABLE_WORLD = check("worlds.enabled", ENABLE_WORLD);
         ENABLE_WORLD_BLACKLIST = check("worlds.blacklist", ENABLE_WORLD_BLACKLIST);

--- a/src/main/java/com/syntaxphoenix/spigot/smoothtimber/version/changer/v1_11xChanger.java
+++ b/src/main/java/com/syntaxphoenix/spigot/smoothtimber/version/changer/v1_11xChanger.java
@@ -74,9 +74,13 @@ public class v1_11xChanger implements VersionChanger {
     @Override
     public boolean isWoodBlockImpl(Block block) {
         Material material = block.getType();
-
+        
         if (CutterConfig.ENABLE_EXCLUSION && CutterConfig.EXCLUDED_MATERIALS.contains(material)) {
             return false;
+        }
+        
+        if (CutterConfig.ENABLE_INCLUSION && CutterConfig.INCLUDED_MATERIALS.contains(material)) {
+            return true;
         }
 
         return material == LOG || material == LOG_2 || material == FENCE;
@@ -166,7 +170,11 @@ public class v1_11xChanger implements VersionChanger {
 
     @Override
     public WoodType getWoodTypeFromBlock(Block block) {
-        return getWoodType(block.getType(), block.getData());
+        Material blockMaterial = block.getType();
+        if (CutterConfig.ENABLE_INCLUSION && CutterConfig.INCLUDED_MATERIALS.contains(blockMaterial)) {
+            return WoodType.OTHER;
+        }
+        return getWoodType(blockMaterial, block.getData());
     }
 
     @Override

--- a/src/main/java/com/syntaxphoenix/spigot/smoothtimber/version/changer/v1_13xChanger.java
+++ b/src/main/java/com/syntaxphoenix/spigot/smoothtimber/version/changer/v1_13xChanger.java
@@ -79,6 +79,10 @@ public class v1_13xChanger implements VersionChanger {
         if (CutterConfig.ENABLE_EXCLUSION && CutterConfig.EXCLUDED_MATERIALS.contains(material)) {
             return false;
         }
+        
+        if (CutterConfig.ENABLE_INCLUSION && CutterConfig.INCLUDED_MATERIALS.contains(material)) {
+            return true;
+        }
 
         return getWoodType(material) != null;
     }
@@ -141,7 +145,11 @@ public class v1_13xChanger implements VersionChanger {
 
     @Override
     public WoodType getWoodTypeFromBlock(Block block) {
-        return getWoodType(block.getBlockData().getMaterial());
+        Material blockMaterial = block.getBlockData().getMaterial();
+        if (CutterConfig.ENABLE_INCLUSION && CutterConfig.INCLUDED_MATERIALS.contains(blockMaterial)) {
+            return WoodType.OTHER;
+        }
+        return getWoodType(blockMaterial);
     }
 
     @Override

--- a/src/main/java/com/syntaxphoenix/spigot/smoothtimber/version/changer/v1_16xChanger.java
+++ b/src/main/java/com/syntaxphoenix/spigot/smoothtimber/version/changer/v1_16xChanger.java
@@ -18,6 +18,8 @@ import com.syntaxphoenix.spigot.smoothtimber.version.manager.VersionChanger;
 import com.syntaxphoenix.spigot.smoothtimber.version.manager.VersionExchanger;
 import com.syntaxphoenix.spigot.smoothtimber.version.manager.WoodType;
 
+import static org.bukkit.Bukkit.getLogger;
+
 public class v1_16xChanger implements VersionChanger {
 
     @Override
@@ -79,6 +81,11 @@ public class v1_16xChanger implements VersionChanger {
         if (CutterConfig.ENABLE_EXCLUSION && CutterConfig.EXCLUDED_MATERIALS.contains(material)) {
             return false;
         }
+        
+        if (CutterConfig.ENABLE_INCLUSION && CutterConfig.INCLUDED_MATERIALS.contains(material)) {
+            //getLogger().info("INCLUDED MAT : "+material.toString());
+            return true;
+        }
 
         return getWoodType(material) != null;
     }
@@ -136,7 +143,11 @@ public class v1_16xChanger implements VersionChanger {
 
     @Override
     public WoodType getWoodTypeFromBlock(Block block) {
-        return getWoodType(block.getBlockData().getMaterial());
+        Material blockMaterial = block.getBlockData().getMaterial();
+        if (CutterConfig.ENABLE_INCLUSION && CutterConfig.INCLUDED_MATERIALS.contains(blockMaterial)) {
+            return WoodType.OTHER;
+        }
+        return getWoodType(blockMaterial);
     }
 
     @Override

--- a/src/main/java/com/syntaxphoenix/spigot/smoothtimber/version/changer/v1_8xChanger.java
+++ b/src/main/java/com/syntaxphoenix/spigot/smoothtimber/version/changer/v1_8xChanger.java
@@ -78,6 +78,10 @@ public class v1_8xChanger implements VersionChanger {
         if (CutterConfig.ENABLE_EXCLUSION && CutterConfig.EXCLUDED_MATERIALS.contains(material)) {
             return false;
         }
+        
+        if (CutterConfig.ENABLE_INCLUSION && CutterConfig.INCLUDED_MATERIALS.contains(material)) {
+            return true;
+        }
 
         return material == LOG || material == LOG_2 || material == FENCE;
     }
@@ -164,7 +168,11 @@ public class v1_8xChanger implements VersionChanger {
 
     @Override
     public WoodType getWoodTypeFromBlock(Block block) {
-        return getWoodType(block.getType(), block.getData());
+        Material blockMaterial = block.getType();
+        if (CutterConfig.ENABLE_INCLUSION && CutterConfig.INCLUDED_MATERIALS.contains(blockMaterial)) {
+            return WoodType.OTHER;
+        }
+        return getWoodType(blockMaterial, block.getData());
     }
 
     @Override

--- a/src/main/java/com/syntaxphoenix/spigot/smoothtimber/version/changer/v1_9xChanger.java
+++ b/src/main/java/com/syntaxphoenix/spigot/smoothtimber/version/changer/v1_9xChanger.java
@@ -78,6 +78,10 @@ public class v1_9xChanger implements VersionChanger {
         if (CutterConfig.ENABLE_EXCLUSION && CutterConfig.EXCLUDED_MATERIALS.contains(material)) {
             return false;
         }
+        
+        if (CutterConfig.ENABLE_INCLUSION && CutterConfig.INCLUDED_MATERIALS.contains(material)) {
+            return true;
+        }
 
         return material == LOG || material == LOG_2 || material == FENCE;
     }
@@ -166,7 +170,11 @@ public class v1_9xChanger implements VersionChanger {
 
     @Override
     public WoodType getWoodTypeFromBlock(Block block) {
-        return getWoodType(block.getType(), block.getData());
+        Material blockMaterial = block.getType();
+        if (CutterConfig.ENABLE_INCLUSION && CutterConfig.INCLUDED_MATERIALS.contains(blockMaterial)) {
+            return WoodType.OTHER;
+        }
+        return getWoodType(blockMaterial, block.getData());
     }
 
     @Override

--- a/src/main/java/com/syntaxphoenix/spigot/smoothtimber/version/manager/WoodType.java
+++ b/src/main/java/com/syntaxphoenix/spigot/smoothtimber/version/manager/WoodType.java
@@ -9,6 +9,7 @@ public enum WoodType {
     DARKOAK,
     ACACIA,
     WARPED,
-    CRIMSON;
+    CRIMSON,
+    OTHER;
 
 }


### PR DESCRIPTION
Hi,

This plugin is very usefull but in my case and for some other user (https://github.com/SourceWriters/SmoothTimber/issues/17), we would like to have leaves support.

More than adding only leaves, this commit add the ability to define a list of blocks (the same way the exclusion works) in the config that will be processed by the resolver.

The code modifications are quite small and are implemented for all supported version of minecraft of the plugin.

I hope it can be added in the main plugin.

Have a nice day.
Best regards,
Oxina