### PR TITLE
Add explicit folia support

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -4,6 +4,7 @@ author: SyntaxPhoenix IT-Solutions
 version: ${projectVersion}
 api-version: 1.13
 softdepend: [BlockyLog, WorldGuard, Residence, Lands, Jobs, GriefPrevention, PlaceholderAPI, CoreProtect, LogBlock, mcMMO, Towny]
+folia-supported: true
 
 commands:
     smoothtimber:


### PR DESCRIPTION
It look like the only thing that was missing where this line in plugin.yml.

I have test it on my local folia server in 1.20.1 with default config & all axes.

Close https://github.com/SourceWriters/SmoothTimber/issues/72