### PR TITLE
Added file needed for support under Spigot 1.21

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -60,6 +60,14 @@
               <shadedPattern>net.coreprotect</shadedPattern>
             </relocation>
             <relocation>
+              <pattern>lands.v1</pattern>
+              <shadedPattern>me.angeschossen.lands</shadedPattern>
+            </relocation>
+            <relocation>
+              <pattern>lands.v2</pattern>
+              <shadedPattern>me.angeschossen.lands</shadedPattern>
+            </relocation>
+            <relocation>
               <pattern>mcmmo.v1.com</pattern>
               <shadedPattern>com</shadedPattern>
             </relocation>
@@ -157,12 +165,6 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.github.angeschossen</groupId>
-      <artifactId>LandsAPI</artifactId>
-      <version>4.10.18</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
       <groupId>com.github.TechFortress</groupId>
       <artifactId>GriefPrevention</artifactId>
       <version>16.16.0</version>
@@ -241,6 +243,20 @@
       <artifactId>roaster-jdt</artifactId>
       <version>2.28.0.Final</version>
       <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>lands</groupId>
+      <artifactId>lands1</artifactId>
+      <version>1</version>
+      <scope>system</scope>
+      <systemPath>${project.basedir}/libraries/LandsAPI.repackaged.jar</systemPath>
+    </dependency>
+    <dependency>
+      <groupId>lands</groupId>
+      <artifactId>lands2</artifactId>
+      <version>1</version>
+      <scope>system</scope>
+      <systemPath>${project.basedir}/libraries/lands-api-7.0.2.repackaged.jar</systemPath>
     </dependency>
     <dependency>
       <groupId>net.coreprotect</groupId>

--- a/src/main/java/com/syntaxphoenix/spigot/smoothtimber/version/changer/v1_21xChanger.java
+++ b/src/main/java/com/syntaxphoenix/spigot/smoothtimber/version/changer/v1_21xChanger.java
@@ -1,0 +1,252 @@
+package com.syntaxphoenix.spigot.smoothtimber.version.changer;
+
+import com.syntaxphoenix.spigot.smoothtimber.annotation.SupportedVersions;
+import com.syntaxphoenix.spigot.smoothtimber.config.config.CutterConfig;
+import com.syntaxphoenix.spigot.smoothtimber.utilities.Lists;
+import com.syntaxphoenix.spigot.smoothtimber.version.manager.VersionChanger;
+import com.syntaxphoenix.spigot.smoothtimber.version.manager.VersionExchanger;
+import com.syntaxphoenix.spigot.smoothtimber.version.manager.WoodType;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.FallingBlock;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.inventory.meta.ItemMeta;
+
+@SupportedVersions({
+    "1.21",
+})
+public final class v1_21xChanger implements VersionChanger {
+
+    @Override
+    public boolean hasCuttingItemInHand(final Player player) {
+        return CutterConfig.CUTTER_MATERIALS.contains(getItemInHand(player).getType().name());
+    }
+
+    @Override
+    public boolean hasPermissionForCuttingItem(final Player player, final ItemStack item) {
+        if (!CutterConfig.ENABLE_CUTTER_PERMISSIONS || item == null) {
+            return true;
+        }
+        return VersionExchanger.checkPermission(item.getType().name().toLowerCase(), player);
+    }
+
+    @Override
+    public byte getData(final BlockState block) {
+        return 0;
+    }
+
+    @Override
+    public ItemStack removeDurabilityFromItem(final ItemStack stack) {
+        if (CutterConfig.ENABLE_UNBREAKING) {
+            final int level = stack.getEnchantmentLevel(Enchantment.DURABILITY);
+            final float chance = 100 / (level <= 0 ? 1 : level + 1);
+            if (RANDOM.nextFloat(0, 100) > chance) {
+                return stack;
+            }
+        }
+        final ItemMeta meta = stack.getItemMeta();
+        if (meta.isUnbreakable()) {
+            return stack;
+        }
+        if (meta instanceof Damageable) {
+            final Damageable dmg = (Damageable) meta;
+            final int damage = dmg.getDamage() + 1;
+            if (stack.getType().getMaxDurability() - damage < 0) {
+                stack.setAmount(0);
+                return null;
+            }
+            dmg.setDamage(damage);
+        }
+        stack.setItemMeta(meta);
+        return stack;
+    }
+
+    @Override
+    public int getMaxDropCount(final ItemStack stack) {
+        final int level = stack.getEnchantmentLevel(Enchantment.LOOT_BONUS_BLOCKS);
+        return level <= 0 ? 1 : level + 1;
+    }
+
+    @Override
+    public void setItemInPlayerHand(final Player player, final ItemStack stack) {
+        player.getEquipment().setItemInMainHand(stack);
+    }
+
+    @Override
+    public boolean isWoodBlockImpl(final BlockState block) {
+        final Material material = block.getBlockData().getMaterial();
+
+        if (CutterConfig.ENABLE_EXCLUSION && CutterConfig.EXCLUDED_MATERIALS.contains(material)) {
+            return false;
+        }
+
+        if (CutterConfig.ENABLE_INCLUSION && CutterConfig.INCLUDED_MATERIALS.contains(material)) {
+            return true;
+        }
+
+        return getWoodType(material) != WoodType.OTHER;
+    }
+
+    @Override
+    public void setupConfig() {
+        CutterConfig.CUTTER_MATERIALS
+            .addAll(Lists.asList("WOODEN_AXE", "STONE_AXE", "IRON_AXE", "GOLDEN_AXE", "DIAMOND_AXE", "NETHERITE_AXE"));
+    }
+
+    @Override
+    public boolean hasPermissionForWood(final Player p, final Block b) {
+        return hasPermissionForWoodType(p, getWoodType(b.getBlockData().getMaterial()));
+    }
+
+    @Override
+    public boolean hasPermissionForWoodType(final Player p, final WoodType type) {
+        if (!CutterConfig.ENABLE_WOOD_PERMISSIONS || type == null) {
+            return true;
+        }
+        return VersionExchanger.checkPermission(type, p);
+    }
+
+    @Override
+    public ItemStack getItemInHand(final Player p) {
+        return p.getEquipment().getItemInMainHand();
+    }
+
+    @Override
+    public ItemStack getItemFromBlock(final Block block) {
+        return new ItemStack(block.getBlockData().getMaterial());
+    }
+
+    @Override
+    public ItemStack getItemFromFallingBlock(final FallingBlock block) {
+        return new ItemStack(block.getBlockData().getMaterial());
+    }
+
+    @Override
+    public ItemStack getAirItem() {
+        return new ItemStack(Material.AIR);
+    }
+
+    @Override
+    public void setAirBlock(final Block block) {
+        block.setType(Material.AIR);
+    }
+
+    @Override
+    public Entity toFallingBlock(final Block block) {
+        final BlockData data = block.getBlockData();
+        block.setType(Material.AIR);
+        return block.getWorld().spawnFallingBlock(block.getLocation().add(0.5, 0.2, 0.5), data);
+    }
+
+    @Override
+    public EntityType getFallingBlockType() {
+        return EntityType.FALLING_BLOCK;
+    }
+
+    @Override
+    public boolean isSupported(final WoodType type) {
+        switch (type) {
+        case OAK:
+        case SPRUCE:
+        case BIRCH:
+        case JUNGLE:
+        case ACACIA:
+        case DARKOAK:
+        case CRIMSON:
+        case WARPED:
+        case MANGROVE:
+        case CHERRY:
+        case OTHER:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    @Override
+    public WoodType getWoodTypeFromBlock(final Block block) {
+        final Material blockMaterial = block.getBlockData().getMaterial();
+        if (CutterConfig.ENABLE_INCLUSION && CutterConfig.INCLUDED_MATERIALS.contains(blockMaterial)) {
+            return WoodType.OTHER;
+        }
+        return getWoodType(blockMaterial);
+    }
+
+    @Override
+    public WoodType getWoodType(final Material type, final int id) {
+        switch (type) {
+        case OAK_LOG:
+        case OAK_WOOD:
+        case OAK_FENCE:
+        case STRIPPED_OAK_LOG:
+        case STRIPPED_OAK_WOOD:
+            return WoodType.OAK;
+        case SPRUCE_LOG:
+        case SPRUCE_WOOD:
+        case SPRUCE_FENCE:
+        case STRIPPED_SPRUCE_LOG:
+        case STRIPPED_SPRUCE_WOOD:
+            return WoodType.SPRUCE;
+        case BIRCH_LOG:
+        case BIRCH_WOOD:
+        case BIRCH_FENCE:
+        case STRIPPED_BIRCH_LOG:
+        case STRIPPED_BIRCH_WOOD:
+            return WoodType.BIRCH;
+        case JUNGLE_LOG:
+        case JUNGLE_WOOD:
+        case JUNGLE_FENCE:
+        case STRIPPED_JUNGLE_LOG:
+        case STRIPPED_JUNGLE_WOOD:
+            return WoodType.JUNGLE;
+        case DARK_OAK_LOG:
+        case DARK_OAK_WOOD:
+        case DARK_OAK_FENCE:
+        case STRIPPED_DARK_OAK_LOG:
+        case STRIPPED_DARK_OAK_WOOD:
+            return WoodType.DARKOAK;
+        case ACACIA_LOG:
+        case ACACIA_WOOD:
+        case ACACIA_FENCE:
+        case STRIPPED_ACACIA_LOG:
+        case STRIPPED_ACACIA_WOOD:
+            return WoodType.ACACIA;
+        case MANGROVE_LOG:
+        case MANGROVE_WOOD:
+        case MANGROVE_FENCE:
+        case STRIPPED_MANGROVE_LOG:
+        case STRIPPED_MANGROVE_WOOD:
+        case MANGROVE_ROOTS:
+        case MUDDY_MANGROVE_ROOTS:
+            return WoodType.MANGROVE;
+        case CRIMSON_STEM:
+        case CRIMSON_FENCE:
+        case CRIMSON_HYPHAE:
+        case STRIPPED_CRIMSON_STEM:
+        case STRIPPED_CRIMSON_HYPHAE:
+            return WoodType.CRIMSON;
+        case WARPED_STEM:
+        case WARPED_FENCE:
+        case WARPED_HYPHAE:
+        case STRIPPED_WARPED_STEM:
+        case STRIPPED_WARPED_HYPHAE:
+            return WoodType.WARPED;
+        case CHERRY_LOG:
+        case CHERRY_WOOD:
+        case CHERRY_FENCE:
+        case STRIPPED_CHERRY_LOG:
+        case STRIPPED_CHERRY_WOOD:
+            return WoodType.CHERRY;
+        default:
+            return WoodType.OTHER;
+        }
+    }
+
+}


### PR DESCRIPTION
Added experimental support for 1.21 Spigot.
Unfortunately, due to the lack of a Folia 1.21 build, some concessions had to be made.
Building will fail if the server version is updated to 1.21 in the pom, as folia-api has no viable builds. To solve this, I've left the server version as 1.20.1, and confirm that it both builds **and** runs under Spigot/PaperMC 1.21
While not preferred, this does allow for operators of 1.21 servers to use the plugin in these months while we wait on Folia 1.21 support.